### PR TITLE
IPMI board support

### DIFF
--- a/Ipmi/Ipmi.py
+++ b/Ipmi/Ipmi.py
@@ -38,7 +38,7 @@ class Ipmi(object):
             return False
 
         proc = subprocess.Popen(
-            ['sudo','ipmitool', 'sensor'],
+            ['sudo', 'ipmitool', 'sensor'],
             stdout=subprocess.PIPE,
             close_fds=True)
 
@@ -71,11 +71,11 @@ class Ipmi(object):
             match = cpu_matcher(sensor)
             if match:
                 if match.group(1):
-                    cpu_num = match.group(1)
+                    key = 'temp-cpu-{0}'.format(match.group(1))
                 else:
-                    cpu_num = 1
+                    key = 'temp-cpu-1'
 
-                data['temp-cpu-{0}'.format(cpu_num)] = float(sensor.split('|')[1].strip())
+                data[key] = float(sensor.split('|')[1].strip())
 
         return data
 
@@ -99,7 +99,6 @@ class Ipmi(object):
 
         return data
 
-
     def process_fans(self):
         """Collect speed from all available Fans"""
         data = {}
@@ -111,7 +110,8 @@ class Ipmi(object):
             if match:
                 columns = sensor.split('|')
                 if columns[1].strip() != 'na':
-                    data['speed-fan-{0}'.format(match.group(1))] = float(columns[1].strip())
+                    key = 'speed-fan-{0}'.format(match.group(1))
+                    data[key] = float(columns[1].strip())
 
         return data
 
@@ -126,7 +126,8 @@ class Ipmi(object):
             if match:
                 columns = sensor.split('|')
                 if columns[1].strip() != 'na':
-                    data['power-supply-{0}'.format(match.group(1))] = int(columns[1].strip(), 16)
+                    key = 'power-supply-{0}'.format(match.group(1))
+                    data[key] = int(columns[1].strip(), 16)
 
         return data
 

--- a/Ipmi/Ipmi.py
+++ b/Ipmi/Ipmi.py
@@ -19,6 +19,7 @@ import time
 class Ipmi(object):
     """SD Plugin for reading available data from the machines IPMI board sensors.
 
+    Requires sudo permissions to run 'ipmitool sensor'.
     We need tools to be installed to query the IPMI interface:
 
     * ipmitool - http://ipmitool.sourceforge.net/

--- a/Ipmi/Ipmi.py
+++ b/Ipmi/Ipmi.py
@@ -1,0 +1,133 @@
+"""
+  Server Density Plugin
+  IPMI measurements (temp, fan, power)
+
+  https://github.com/serverdensity/sd-agent-plugins/
+
+
+  Version: 1.0.0
+"""
+
+import re
+import json
+import logging
+import sys
+import subprocess
+import time
+
+
+class Ipmi(object):
+    """SD Plugin for reading available data from the machines IPMI board sensors.
+
+    We need tools to be installed to query the IPMI interface:
+
+    * ipmitool - http://ipmitool.sourceforge.net/
+    """
+
+    def __init__(self, agent_config, checks_logger, raw_config):
+        self.agent_config = agent_config
+        self.checks_logger = checks_logger
+        self.raw_config = raw_config
+
+    def run(self):
+
+        data = {}
+
+        if 'Ipmi' not in self.raw_config:
+            return False
+
+        proc = subprocess.Popen(
+            ['ipmitool', 'sensor'],
+            stdout=subprocess.PIPE,
+            close_fds=True)
+
+        self.sensors = proc.communicate()[0]
+
+        if self.raw_config['Ipmi']['cpus'] == 'yes':
+            data.update(self.process_cpus())
+
+        if self.raw_config['Ipmi']['system'] == 'yes':
+            data.update(self.process_system())
+
+        if self.raw_config['Ipmi']['peripheral'] == 'yes':
+            data.update(self.process_peripheral())
+
+        if self.raw_config['Ipmi']['fans'] == 'yes':
+            data.update(self.process_fans())
+
+        return data
+
+    def process_cpus(self):
+        """Collect temperatures from all available CPUs"""
+        data = {}
+
+        cpu_matcher = re.compile(r'^CPU(\d+)\sTemp').match
+
+        for sensor in self.sensors.split("\n"):
+            match = cpu_matcher(sensor)
+            if match:
+                data['temp-cpu-{0}'.format(match.group(1))] = sensor.split('|')[1].strip()
+
+        return data
+
+    def process_system(self):
+        """Collect system temperature"""
+        data = {}
+
+        for sensor in self.sensors.split("\n"):
+            if sensor.startswith('System Temp'):
+                data['temp-system'] = sensor.split('|')[1].strip()
+
+        return data
+
+    def process_peripheral(self):
+        """Collect peripheral temperature"""
+        data = {}
+
+        for sensor in self.sensors.split("\n"):
+            if sensor.startswith('Peripheral Temp'):
+                data['temp-peripheral'] = sensor.split('|')[1].strip()
+
+        return data
+
+
+    def process_fans(self):
+        """Collect speed from all available Fans"""
+        data = {}
+
+        fan_matcher = re.compile(r'^FAN(\d+)').match
+
+        for sensor in self.sensors.split("\n"):
+            match = fan_matcher(sensor)
+            if match:
+                columns = sensor.split('|')
+                if columns[1].strip() != 'na':
+                    data['speed-fan-{0}'.format(match.group(1))] = columns[1].strip()
+
+        return data
+
+if __name__ == '__main__':
+    """Standalone test
+    """
+
+    raw_agent_config = {
+        'Ipmi': {
+            'cpus': 'yes',
+            'system': 'yes',
+            'peripheral': 'yes',
+            'fans': 'yes',
+        }
+    }
+
+    main_checks_logger = logging.getLogger('Ipmi')
+    main_checks_logger.setLevel(logging.DEBUG)
+    main_checks_logger.addHandler(logging.StreamHandler(sys.stdout))
+    ipmi_check = Ipmi({}, main_checks_logger, raw_agent_config)
+
+    while True:
+        try:
+            print json.dumps(ipmi_check.run(), indent=4, sort_keys=True)
+        except:
+            main_checks_logger.exception("Unhandled exception")
+        finally:
+            time.sleep(5)

--- a/Ipmi/README.md
+++ b/Ipmi/README.md
@@ -1,0 +1,53 @@
+IPMI Monitor
+===
+
+This plugin is for [ipmitool](http://ipmitool.sourceforge.net/).
+
+Setup
+---
+
+To query your local IPMI board using ipmitool the plugin needs to execute the following
+using sudo:
+
+`sudo ipmitool sensor`
+
+Depending on how you are running the agent you maybe need to give the sd-agent more permissions.
+[plugins requiring sudo](https://support.serverdensity.com/hc/en-us/articles/201253683-Plugins-requiring-sudo)
+has more information.
+
+Linux
+---
+1. You must have installed [ipmitool](http://ipmitool.sourceforge.net/).
+2. Ensure the command `ipmitool sensor` outputs the correct data.
+
+Metrics
+---
+* CPU temperature (individual)
+* System temperature
+* Peripheral temperature
+* Fan speeds
+* Powersupply status
+
+Recommended alerts
+---
+* `temp-cpu-*` - CPU temperatues, if this suddenly spikes or increases a fan might be broken.
+* `temp-system` - Sensors on the mainboard, raised values might indicate air intake into the case is broken.
+* `temp-peripheral` - Peripheral temperatures, raised values might indicate A/C problems or a fire in your datacenter.
+* `speed-fan-*` - Fan speeds (RPM), a value of 0 would indicate that your fan is broken.
+* `power-supply-*` - Power supply status, a value of 0 would indicate a unplugged supply.
+
+Configuration
+---
+```
+[Ipmi]
+# report CPU temp
+cpus: yes
+# report system temp
+system: yes
+# report peripheral temp
+peripheral: yes
+# report fan speeds (RPM)
+fans: yes
+# report power status
+powersupply: yes
+```


### PR DESCRIPTION
Hi,

this small plugin uses ipmitool to query temperatures, fan speeds and powersupply status. Number of CPUs, fans and power supplies is fetched dynamically. Requires sudo permissions to run 'ipmitool sensors'. 

Example output:

```
{
    "power-supply-1": 1,
    "power-supply-2": 1,
    "speed-fan-2": 2925.0,
    "speed-fan-4": 3000.0,
    "speed-fan-B": 3000.0,
    "temp-cpu-1": 34.0,
    "temp-cpu-2": 36.0,
    "temp-peripheral": 33.0,
    "temp-system": 27.0
}
```

Cheers :beers: 
Daniel