### PR TITLE
PortMon: Check TCP Ports are Reachable

### DIFF
--- a/PortMon/.gitignore
+++ b/PortMon/.gitignore
@@ -1,0 +1,54 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/PortMon/LICENSE
+++ b/PortMon/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Alex Hewson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/PortMon/PortMon.py
+++ b/PortMon/PortMon.py
@@ -47,7 +47,7 @@ class PortMon(object):
             #s.recv(0)
             s.close()
         except (socket.error, socket.timeout):
-            return None
+            return 'down'
         return ret
         
         

--- a/PortMon/PortMon.py
+++ b/PortMon/PortMon.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import time
+import socket
+
+
+class PortMon(object):
+    '''
+    Config should be in /etc/sd-agent/config.cfg like:
+    
+    portmon_timeout: 5
+    portmon_targets: 127.0.0.1:22,192.168.3.4:5678
+    
+    Multiple targets to be monitored should be separated with a ','.
+    '''
+    
+    def __init__(self, agentConfig, checksLogger, rawConfig):
+        self.agentConfig    = agentConfig
+        self.checksLogger   = checksLogger
+        self.rawConfig      = rawConfig
+        
+        self.timeout    = int( rawConfig['Main'].get('portmon_timeout', 10) )
+        targets_str     = rawConfig['Main'].get('portmon_targets', '').strip()
+        if len(targets_str):
+            self.targets = targets_str.split(',')
+        else:
+            self.targets = []
+        
+    
+    def run(self):
+        target_times = {}
+        for t in self.targets:
+            host, port = t.split(':')
+            target_times[t.replace('.','_')] = self.timeConnect(host, int(port))
+        return target_times
+        
+    
+    def timeConnect(self, host, port):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(self.timeout)
+        t_init = time.time()
+        #ret = None
+        try:
+            s.connect((host, port))
+            ret = time.time() - t_init
+            #s.recv(0)
+            s.close()
+        except (socket.error, socket.timeout):
+            return None
+        return ret
+        
+        
+if __name__ == "__main__":
+    
+    # Test ports: one that's not accessible and another that's open on my
+    # MacBook.
+    fake_rawConfig = {
+        'portmon_targets':  "127.0.0.1:8542,192.168.6.6:1200",
+        'portmon_timeout':  "10"
+    }
+    pm = PortMon({}, {}, fake_rawConfig)
+    print pm.run()
+    

--- a/PortMon/README.md
+++ b/PortMon/README.md
@@ -1,0 +1,59 @@
+# ServerDensity-PortMon
+Remote TCP port monitoring plugin for ServerDensity.
+
+Tests whether a TCP port on a (potentially) remote machine can be reached from your ServerDensity-monitored host and records the time a connect() took.
+
+
+## Potential Uses
+
+ServerDensity makes it very easy to monitor the status of a given server, but it doesn't offer any tools to check connectivity to external services your application depends on.  Examples include:
+
+*   Databases
+*   SSH Tunnels
+*   External APIs
+
+This means it's possible for SD to report your hosting platform as A-OK (which technically it is) but for your website to be a smoking crater because the application can't reach some external resource.
+
+Enter PortMon - a plugin to check your hosts can connect to TCP ports elsewhere and measure the time taken for connect() to complete.
+
+
+## Configuration
+
+Config is intentionally simple.  Create the following section in your ServerDensity agent config, usually `/etc/sd-agent/config.cfg`.
+
+Requires plugins to be enabled - in your config.cfg have something like:
+
+```plugin_directory: /usr/local/sd-agent/plugins```
+
+Config looks like:
+
+```
+portmon_timeout: 5
+portmon_targets: 127.0.0.1:22,my-rds-db.abcdef91p1.eu-west-1.rds.amazonaws.com:1433
+```
+
+Settings are simply:
+
+*  `portmon_timeout` - Integer timeout for connection attempts.  If this is reached the plugin records None for that target and goes on for the next.
+*  `portmon_targets` - A comma-separated list of TCP hosts/ports in the form `host:port`.
+
+
+## Return Values
+
+For each target you define you'll get back a key/value pair of:
+
+*   Key - target hostname with all periods replaced with underscores.  (Why?  Because ServerDensity doesn't support periods in the key names)
+*   Value - Number of seconds it took to connect to the resource.
+
+The values are eminently suitable for alerting and publishing on dashboard graphs, either all-in-one or separately.
+
+
+## License
+
+MIT.  See /LICENSE.
+
+
+## Acknowledgements
+
+This plugin was originally developed by [@alexmbird](https://github.com/alexmbird/) for [The Dextrous Web Ltd](https://www.dxw.com/).
+


### PR DESCRIPTION
A small plugin to test whether we can connect to a (potentially remote) TCP port.  Returns the time taken to connect() or 'down' if it couldn't be reached.  Useful for checking your servers can reach remote dependencies like databases and API's.