### PR TITLE
Add free memory plugin

### DIFF
--- a/FreeMemory/FreeMemory.py
+++ b/FreeMemory/FreeMemory.py
@@ -1,0 +1,34 @@
+import subprocess
+import re
+
+
+class FreeMemory:
+    def __init__(self, agentConfig, checksLogger, rawConfig):
+        self.agentConfig = agentConfig
+        self.checksLogger = checksLogger
+        self.rawConfig = rawConfig
+
+    def run(self):
+        data = {}
+
+        p = subprocess.Popen(
+            ['free', '-m'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        freeOutput, errorOutput = p.communicate()
+
+        self.checksLogger.debug(
+            'Free memory command output: {0}'.format(freeOutput)
+        )
+
+        if errorOutput:
+            self.checksLogger.error(
+                'Error executing memory information: {0}'.format(errorOutput))
+
+        matches = re.search('cache:\s+\d+\s+(?P<total_free>\d+)', freeOutput)
+
+        if matches:
+            data['Free memory'] = matches.group('total_free')
+
+        return data

--- a/FreeMemory/README.md
+++ b/FreeMemory/README.md
@@ -1,0 +1,2 @@
+#Free memory Plugin
+This is a very simple plugin that provides an accurate free memory metric based on the `free` command. It solves the problem of the default memory metris not accounting for cached memory, which can cause low memory alerts on servers that are holding a large cache.


### PR DESCRIPTION
This addresses a recent issue I've had where the default memory monitoring doesn't take into account the amount of memory being held in cache. The result is that setting up an alert for free memory less than 10% is useless, because it fires as soon as the OS allocates the spare memory for cache.