### PR TITLE
Rename the FreeMemory plugin to AvailableMemory

### DIFF
--- a/AvailableMemory/AvailableMemory.py
+++ b/AvailableMemory/AvailableMemory.py
@@ -2,7 +2,7 @@ import subprocess
 import re
 
 
-class FreeMemory:
+class AvailableMemory:
     def __init__(self, agentConfig, checksLogger, rawConfig):
         self.agentConfig = agentConfig
         self.checksLogger = checksLogger
@@ -26,9 +26,9 @@ class FreeMemory:
             self.checksLogger.error(
                 'Error executing memory information: {0}'.format(errorOutput))
 
-        matches = re.search('cache:\s+\d+\s+(?P<total_free>\d+)', freeOutput)
+        matches = re.search('cache:\s+\d+\s+(?P<available>\d+)', freeOutput)
 
         if matches:
-            data['Free memory'] = matches.group('total_free')
+            data['Available memory'] = matches.group('available')
 
         return data

--- a/AvailableMemory/README.md
+++ b/AvailableMemory/README.md
@@ -1,0 +1,2 @@
+#Available memory Plugin
+This is a very simple plugin that provides an accurate available memory metric based on the `free` command. It solves the problem of the default memory metrics not accounting for buffers/cached memory, which can cause low memory alerts on servers that are holding a large cache.

--- a/FreeMemory/README.md
+++ b/FreeMemory/README.md
@@ -1,2 +1,0 @@
-#Free memory Plugin
-This is a very simple plugin that provides an accurate free memory metric based on the `free` command. It solves the problem of the default memory metris not accounting for cached memory, which can cause low memory alerts on servers that are holding a large cache.


### PR DESCRIPTION
It's missleading to replace the free memory amount with what is normally called available memory.

This work corrects that by renaming the plugin and data to use "Available memory" instead, allowing for both free and available memory to be accessible for alerts.