### PR TITLE
Zoo keeper

### DIFF
--- a/ZooKeeper/ZooKeeper.py
+++ b/ZooKeeper/ZooKeeper.py
@@ -10,7 +10,6 @@ Version: 1.0.0
 """
 
 import socket
-import traceback
 
 
 class ZooKeeper(object):

--- a/ZooKeeper/ZooKeeper.py
+++ b/ZooKeeper/ZooKeeper.py
@@ -29,7 +29,18 @@ class ZooKeeper(object):
         ]
 
     def run(self):
+        if 'ZooKeeper' not in self.raw_config:
+            host = 'localhost'
+            port = 2181
+        else:
+            host = self.raw_config['ZooKeeper'].get(
+                'host', 'localhost')
+            port = int(self.raw_config['ZooKeeper'].get(
+                'port', '2181'))
+
         data = {}
+        data['imok'] = 1
+
         self.checks_logger.debug('ZooKeeper_plugin: started gathering data')
 
         for command in self.zookeeper_commands:
@@ -39,15 +50,6 @@ class ZooKeeper(object):
 
                 # set a timeout for socket operation
                 s.settimeout(4)
-
-                if 'ZooKeeper' not in self.raw_config:
-                    host = 'localhost'
-                    port = 2181
-                else:
-                    host = self.raw_config['ZooKeeper'].get(
-                        'host', 'localhost')
-                    port = int(self.raw_config['ZooKeeper'].get(
-                        'port', '2181'))
 
                 s.connect(
                     (host, port)


### PR DESCRIPTION
The ZooKeeper plugin depends on getting data from ZooKeeper before posting data to ServerDensity

If the ZooKeeper process dies the plugin will not send any data to ServerDensity and there wil be no alert.

By setting imok: 1 before the plugin tries to connect to ZooKeeper, the plugin will always report data to ServerDensity. Now if there is anything wrong with Zookeeper there will be an alert !