### PR TITLE
Rds

### DIFF
--- a/RDS/RDS.py
+++ b/RDS/RDS.py
@@ -225,15 +225,11 @@ class RDS(object):
     def preliminaries(self):
         self.config = {}
         try:
-            # endpoint = self.raw_config['RDS']['endpoint']
-            # identifier, _, region, _, _, _ = endpoint.split('.')
             aws_secret = self.raw_config['RDS']['aws_secret_access_key']
             aws_key = self.raw_config['RDS']['aws_access_key_id']
 
             self.config['aws_key'] = aws_key
             self.config['aws_secret'] = aws_secret
-            # self.config['identifier'] = identifier
-            # self.config['region'] = region
         except IndexError as e:
             self.checks_logger.error(
                 'RDS: Failed to read configuration file: {}'.format(e.message))

--- a/RDS/RDS.py
+++ b/RDS/RDS.py
@@ -222,8 +222,6 @@ class RDS(object):
             'FreeStorageSpace'
         ]
 
-
-
     def preliminaries(self):
         self.config = {}
         try:
@@ -301,8 +299,6 @@ class RDS(object):
 
             # mutable dictionary
             self.fetch_stats(data, rds)
-
-
 
         return data
 

--- a/RDS/RDS.py
+++ b/RDS/RDS.py
@@ -1,0 +1,244 @@
+
+"""
+Server Density plugin
+RDS monitoring script, based on
+https://github.com/percona/percona-monitoring-plugins/blob/master/cacti/scripts/ss_get_rds_stats.py
+
+version: 0.1
+"""
+
+import sys
+import logging
+import json
+import time
+import datetime
+
+import boto
+import boto.rds
+import boto.ec2.cloudwatch
+
+
+class NoDBinstanceError(Exception):
+    pass
+
+
+class NoMetricError(Exception):
+    pass
+
+
+class BotoRDS(object):
+
+    """RDS connection class"""
+
+    def __init__(self, region, aws_key, aws_secret, identifier=None):
+        """Get RDS instance details"""
+        self.region = region
+        self.identifier = identifier
+        self.aws_key = aws_key
+        self.aws_secret = aws_secret
+
+        try:
+            rds_conn = boto.rds.connect_to_region(
+                self.region,
+                aws_access_key_id=self.aws_key,
+                aws_secret_access_key=self.aws_secret
+            )
+            self.info = rds_conn.get_all_dbinstances(self.identifier)[0]
+        except IndexError:
+            raise NoDBinstanceError('No database instance found with identifier: {}'.format(identifier))
+
+    def get_info(self):
+        """Get RDS instance info"""
+        return self.info
+
+    def get_list(self):
+        """Get list of available instances by region(s)"""
+        result = dict()
+        for reg in self.regions_list:
+            try:
+                rds = boto.rds.connect_to_region(
+                    reg,
+                    aws_access_key_id=self.aws_key,
+                    aws_secret_access_key=self.aws_secret
+                )
+                result[reg] = rds.get_all_dbinstances()
+            except (boto.provider.ProfileNotFoundError, boto.exception.BotoServerError):
+                result = {}
+
+        return result
+
+    def get_metric(self, metric):
+        """Get RDS metric from CloudWatch"""
+        cw_conn = boto.ec2.cloudwatch.connect_to_region(
+            self.region,
+            aws_access_key_id=self.aws_key,
+            aws_secret_access_key=self.aws_secret
+        )
+        result = cw_conn.get_metric_statistics(
+            120,  # period of time in seconds we want an average for
+            datetime.datetime.utcnow() - datetime.timedelta(seconds=120),
+            datetime.datetime.utcnow(),
+            metric,
+            'AWS/RDS',
+            'Average',
+            dimensions={'DBInstanceIdentifier': [self.identifier]}
+        )
+        if result:
+            if metric in ('ReadLatency', 'WriteLatency'):
+                # Transform into miliseconds
+                result = '%.2f' % float(result[0]['Average'] * 1000)
+            else:
+                result = '%.2f' % float(result[0]['Average'])
+        else:
+            raise NoMetricError('There are no metric for {} in {}'.format(metric, self.identifier))
+        return float(result)
+
+
+class RDS(object):
+
+    def __init__(self, agent_config, checks_logger, raw_config):
+        self.agent_config = agent_config
+        self.checks_logger = checks_logger
+        self.raw_config = raw_config
+
+        # DB instance classes as listed on
+        # http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html
+        self.db_classes = {
+            'db.t1.micro': 0.615,
+            'db.m1.small': 1.7,
+            'db.m1.medium': 3.75,
+            'db.m1.large': 7.5,
+            'db.m1.xlarge': 15,
+            'db.m4.large': 8,
+            'db.m4.xlarge': 16,
+            'db.m4.2xlarge': 32,
+            'db.m4.4xlarge': 64,
+            'db.m4.10xlarge': 160,
+            'db.r3.large': 15,
+            'db.r3.xlarge': 30.5,
+            'db.r3.2xlarge': 61,
+            'db.r3.4xlarge': 122,
+            'db.r3.8xlarge': 244,
+            'db.t2.micro': 1,
+            'db.t2.small': 2,
+            'db.t2.medium': 4,
+            'db.t2.large': 8,
+            'db.m3.medium': 3.75,
+            'db.m3.large': 7.5,
+            'db.m3.xlarge': 15,
+            'db.m3.2xlarge': 30,
+            'db.m2.xlarge': 17.1,
+            'db.m2.2xlarge': 34.2,
+            'db.m2.4xlarge': 68.4,
+            'db.cr1.8xlarge': 244,
+        }
+
+        # RDS metrics http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/rds-metricscollected.html
+        self.metrics = {
+            'BinLogDiskUsage': 'bin_log_disk_usage',                        # The amount of disk space occupied by binary logs on the master. Only on MySQL read replicas. Units: Bytes
+            'CPUCreditBalance': 'cpucredit_balance',                        # The number of CPU credits that an instance has accumulated. Only valid for T2 instances
+            'CPUCreditUsage': 'cpucredit_usage',                            # The number of CPU credits consumed during the specified period. Only valid for T2 instances.
+            'CPUUtilization': 'cpuutilization',                             # The percentage of CPU utilization.  Units: Percent
+            'DatabaseConnections': 'database_connections',                  # The number of database connections in use.  Units: Count
+            'DiskQueueDepth': 'disk_queue_depth',                           # The number of outstanding IOs (read/write requests) waiting to access the disk.  Units: Count
+            'FreeStorageSpace': 'free_storage_space',                       # The amount of available storage space.  Units: Bytes
+            'FreeableMemory': 'freeable_memory',                            # The amount of available random access memory.  Units: Bytes
+            'MaximumUsedTransactionIDs': 'maximum_used_transaction_ids',
+            'NetworkReceiveThroughput': 'network_received_throughput',      # The incoming (Receive) network traffic on the DB instance. Units: Bytes/second
+            'NetworkTransmitThroughput': 'network_transmit_throughput',     # The outgoing (Transmit) network traffic on the DB instance. Units: Bytes/second
+            'OldestReplicationSlotLag': 'oldest_replication_slot',
+            'ReadIOPS': 'read_iops',                                        # The average number of disk I/O operations per second.  Units: Count/Second
+            'ReadLatency': 'read_latency',                                  # The average amount of time taken per disk I/O operation.  Units: Seconds
+            'ReadThroughput': 'read_throughput',                            # The average number of bytes read from disk per second.  Units: Bytes/Second
+            'ReplicaLag': 'replica_lag',                                    # The amount of time a Read Replica DB Instance lags behind the source DB Instance. Only on replicas. Units: Seconds
+            'SwapUsage': 'swap_usage',                                      # The amount of swap space used on the DB Instance.  Units: Bytes
+            'TransactionLogsDiskUsage': 'transaction_logs_disk_usage',
+            'TransactionLogsGeneration': 'transaction_logs_generation',
+            'WriteIOPS': 'write_iops',                                      # The average number of disk I/O operations per second.  Units: Count/Second
+            'WriteLatency': 'write_latency',                                # The average amount of time taken per disk I/O operation.  Units: Seconds
+            'WriteThroughput': 'write_throughput'                           # The average number of bytes written to disk per second.  Units: Bytes/Second
+
+        }
+
+    def preliminaries(self):
+        self.config = {}
+        try:
+            endpoint = self.raw_config['RDS']['endpoint']
+            identifier, _, region, _, _, _ = endpoint.split('.')
+            self.config['aws_key'] = self.raw_config['RDS']['aws_access_key_id']
+            self.config['aws_secret'] = self.raw_config['RDS']['aws_secret_access_key']
+            self.config['identifier'] = identifier
+            self.config['region'] = region
+        except IndexError as e:
+            self.checks_logger.error('RDS: Failed to read configuration file: {}'.format(e.message))
+            return False
+        return True
+
+    def run(self):
+        if not self.preliminaries():
+            return {}
+
+        data = {}
+
+        try:
+            rds = BotoRDS(**self.config)
+        except NoDBinstanceError as e:
+            self.checks_logger.error('RDS: {}'.format(e.message))
+
+        for metric, values in self.metrics.items():
+            try:
+                stats = rds.get_metric(metric)
+                if metric == 'FreeableMemory':
+                    info = rds.get_info()
+                    try:
+                        memory = self.db_classes[info.instance_class] * 1024 ** 3
+                        data['{0}_{1}'.format(rds.identifier, 'used_memory')] = memory - stats
+                        data['{0}_{1}'.format(rds.identifier, 'total_memory')] = memory
+                        data['{0}_{0}'.format(rds.identifier, self.metrics[metric])] = stats
+                    except IndexError as e:
+                        self.checks_logger.error('RDS: Unknown DB instance class "{}"'.format(info.instance_class))
+                elif metric == 'FreeStorageSpace':
+                    info = rds.get_info()
+                    storage = float(info.allocated_storage) * 1024 ** 3
+                    data['{0}_{1}'.format(rds.identifier, self.metrics[metric])] = stats
+                    data['{0}_{1}'.format(rds.identifier, 'used_diskusage')] = storage - stats
+                    data['{0}_{1}'.format(rds.identifier, 'total_diskUsage')] = storage
+                else:
+                    data['{0}_{1}'.format(rds.identifier, self.metrics[metric])] = stats
+            except NoMetricError as e:
+                self.checks_logger.info('RDS: {} was not available'.format(metric))
+
+        return data
+
+if __name__ == '__main__':
+    """
+    Standalone test configuration
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Configuration input')
+    parser.add_argument('-k', dest='key', help='AWS access key')
+    parser.add_argument('-p', dest='passw', help='AWS secret access key')
+    parser.add_argument('-e', dest='endpoint', help='Endpoint for database')
+    args = parser.parse_args()
+
+    raw_agent_config = {
+        'RDS': {
+            'aws_access_key_id': args.key,
+            'aws_secret_access_key': args.passw,
+            'endpoint': args.endpoint
+        }
+    }
+
+    main_checks_logger = logging.getLogger('RDS')
+    main_checks_logger.setLevel(logging.DEBUG)
+    main_checks_logger.addHandler(logging.StreamHandler(sys.stdout))
+    rds = RDS({}, main_checks_logger, raw_agent_config)
+
+    while True:
+        try:
+            print json.dumps(rds.run(), indent=4, sort_keys=True)
+        except:
+            main_checks_logger.exception("Unhandled exception")
+        finally:
+            time.sleep(60)

--- a/RDS/RDS.py
+++ b/RDS/RDS.py
@@ -292,9 +292,9 @@ class RDS(object):
                 rds = BotoRDS(identifier, region, **self.config)
             except NoDBinstanceError as e:
                 self.checks_logger.error('RDS: {}'.format(e.message))
-
-            # mutable dictionary
-            self.fetch_stats(data, rds)
+            else:
+                # mutable dictionary
+                self.fetch_stats(data, rds)
 
         return data
 

--- a/RDS/RDS.py
+++ b/RDS/RDS.py
@@ -44,7 +44,8 @@ class BotoRDS(object):
             )
             self.info = rds_conn.get_all_dbinstances(self.identifier)[0]
         except IndexError:
-            raise NoDBinstanceError('No database instance found with identifier: {}'.format(identifier))
+            msg = 'No database instance found with identifier: {}'
+            raise NoDBinstanceError(msg.format(identifier))
 
     def get_info(self):
         """Get RDS instance info"""
@@ -61,7 +62,8 @@ class BotoRDS(object):
                     aws_secret_access_key=self.aws_secret
                 )
                 result[reg] = rds.get_all_dbinstances()
-            except (boto.provider.ProfileNotFoundError, boto.exception.BotoServerError):
+            except (boto.provider.ProfileNotFoundError,
+                    boto.exception.BotoServerError):
                 result = {}
 
         return result
@@ -89,7 +91,8 @@ class BotoRDS(object):
             else:
                 result = '%.2f' % float(result[0]['Average'])
         else:
-            raise NoMetricError('There are no metric for {} in {}'.format(metric, self.identifier))
+            raise NoMetricError('There are no metric for {} in {}'.format(
+                                metric, self.identifier))
         return float(result)
 
 
@@ -101,7 +104,8 @@ class RDS(object):
         self.raw_config = raw_config
 
         # DB instance classes as listed on
-        # http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html
+        # http://docs.aws.amazon.com/
+        # AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html
         self.db_classes = {
             'db.t1.micro': 0.615,
             'db.m1.small': 1.7,
@@ -132,31 +136,79 @@ class RDS(object):
             'db.cr1.8xlarge': 244,
         }
 
-        # RDS metrics http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/rds-metricscollected.html
+        # RDS metrics http://docs.aws.amazon.com/
+        # AmazonCloudWatch/latest/DeveloperGuide/rds-metricscollected.html
         self.metrics = {
-            'BinLogDiskUsage': 'bin_log_disk_usage',                        # The amount of disk space occupied by binary logs on the master. Only on MySQL read replicas. Units: megabytes
-            'CPUCreditBalance': 'cpucredit_balance',                        # The number of CPU credits that an instance has accumulated. Only valid for T2 instances
-            'CPUCreditUsage': 'cpucredit_usage',                            # The number of CPU credits consumed during the specified period. Only valid for T2 instances.
-            'CPUUtilization': 'cpuutilization',                             # The percentage of CPU utilization.  Units: Percent
-            'DatabaseConnections': 'database_connections',                  # The number of database connections in use.  Units: Count
-            'DiskQueueDepth': 'disk_queue_depth',                           # The number of outstanding IOs (read/write requests) waiting to access the disk.  Units: Count
-            'FreeStorageSpace': 'free_storage_space',                       # The amount of available storage space.  Units: megabytes
-            'FreeableMemory': 'freeable_memory',                            # The amount of available random access memory.  Units: megabytes
+            # The amount of disk space occupied by binary logs on the master.
+            # Only on MySQL read replicas. Units: megabytes
+            'BinLogDiskUsage': 'bin_log_disk_usage',
+
+            # The number of CPU credits that an instance has accumulated.
+            # Only valid for T2 instances
+            'CPUCreditBalance': 'cpucredit_balance',
+
+            # The number of CPU credits consumed during the specified period.
+            # Only valid for T2 instances.
+            'CPUCreditUsage': 'cpucredit_usage',
+
+            # The percentage of CPU utilization.  Units: Percent
+            'CPUUtilization': 'cpuutilization',
+
+            # The number of database connections in use.  Units: Count
+            'DatabaseConnections': 'database_connections',
+
+            # The number of outstanding IOs (read/write requests) waiting
+            # to access the disk.  Units: Count
+            'DiskQueueDepth': 'disk_queue_depth',
+
+            # The amount of available storage space.  Units: megabytes
+            'FreeStorageSpace': 'free_storage_space',
+
+            # The amount of available random access memory.  Units: megabytes
+            'FreeableMemory': 'freeable_memory',
             'MaximumUsedTransactionIDs': 'maximum_used_transaction_ids',
-            'NetworkReceiveThroughput': 'network_received_throughput',      # The incoming (Receive) network traffic on the DB instance. Units: megabytes/second
-            'NetworkTransmitThroughput': 'network_transmit_throughput',     # The outgoing (Transmit) network traffic on the DB instance. Units: megabytes/second
+
+            # The incoming (Receive) network traffic on the DB instance.
+            # Units: megabytes/second
+            'NetworkReceiveThroughput': 'network_received_throughput',
+
+            # The outgoing (Transmit) network traffic on the DB instance.
+            # Units: megabytes/second
+            'NetworkTransmitThroughput': 'network_transmit_throughput',
             'OldestReplicationSlotLag': 'oldest_replication_slot',
-            'ReadIOPS': 'read_iops',                                        # The average number of disk I/O operations per second.  Units: Count/Second
-            'ReadLatency': 'read_latency',                                  # The average amount of time taken per disk I/O operation.  Units: Seconds
-            'ReadThroughput': 'read_throughput',                            # The average number of megabytes read from disk per second.  Units: megabytes/Second
-            'ReplicaLag': 'replica_lag',                                    # The amount of time a Read Replica DB Instance lags behind the source DB Instance. Only on replicas. Units: Seconds
-            'SwapUsage': 'swap_usage',                                      # The amount of swap space used on the DB Instance.  Units: megabytes
+
+            # The average number of disk I/O operations per second.
+            # Units: Count/Second
+            'ReadIOPS': 'read_iops',
+
+            # The average amount of time taken per disk I/O operation.
+            # Units: Seconds
+            'ReadLatency': 'read_latency',
+
+            # The average number of megabytes read from disk per second.
+            # Units: megabytes/Second
+            'ReadThroughput': 'read_throughput',
+
+            # The amount of time a Read Replica DB Instance lags behind the
+            # source DB Instance. Only on replicas. Units: Seconds
+            'ReplicaLag': 'replica_lag',
+
+            # The amount of swap space used on the DB Instance.
+            # Units: megabytes
+            'SwapUsage': 'swap_usage',
             'TransactionLogsDiskUsage': 'transaction_logs_disk_usage',
             'TransactionLogsGeneration': 'transaction_logs_generation',
-            'WriteIOPS': 'write_iops',                                      # The average number of disk I/O operations per second.  Units: Count/Second
-            'WriteLatency': 'write_latency',                                # The average amount of time taken per disk I/O operation.  Units: Seconds
-            'WriteThroughput': 'write_throughput'                           # The average number of megabytes written to disk per second.  Units: megabytes/Second
 
+            # The average number of disk I/O operations per second.
+            # Units: Count/Second
+            'WriteIOPS': 'write_iops',
+
+            # The average amount of time taken per disk I/O operation.
+            # Units: Seconds
+            'WriteLatency': 'write_latency',
+            # The average number of megabytes written to disk per second.
+            # Units: megabytes/Second
+            'WriteThroughput': 'write_throughput'
         }
 
         self.byte_related = [
@@ -165,7 +217,9 @@ class RDS(object):
             'NetworkTransmitThroughput',
             'ReadThroughput',
             'SwapUsage',
-            'WriteThroughput'
+            'WriteThroughput',
+            'FreeableMemory',
+            'FreeStorageSpace'
         ]
 
     def preliminaries(self):
@@ -173,12 +227,16 @@ class RDS(object):
         try:
             endpoint = self.raw_config['RDS']['endpoint']
             identifier, _, region, _, _, _ = endpoint.split('.')
-            self.config['aws_key'] = self.raw_config['RDS']['aws_access_key_id']
-            self.config['aws_secret'] = self.raw_config['RDS']['aws_secret_access_key']
+            aws_secret = self.raw_config['RDS']['aws_secret_access_key']
+            aws_key = self.raw_config['RDS']['aws_access_key_id']
+
+            self.config['aws_key'] = aws_key
+            self.config['aws_secret'] = aws_secret
             self.config['identifier'] = identifier
             self.config['region'] = region
         except IndexError as e:
-            self.checks_logger.error('RDS: Failed to read configuration file: {}'.format(e.message))
+            self.checks_logger.error(
+                'RDS: Failed to read configuration file: {}'.format(e.message))
             return False
         return True
 
@@ -196,27 +254,39 @@ class RDS(object):
 
             try:
                 stats = rds.get_metric(metric)
+                inst = rds.identifier
+                if metric in self.byte_related:
+                    # formatting to megabytes
+                    stats = stats / 10**6
+
                 if metric == 'FreeableMemory':
                     info = rds.get_info()
                     try:
                         memory = self.db_classes[info.instance_class] * 1000
-                        data['{0}_{1}'.format(rds.identifier, 'used_memory')] = memory - (stats / 10**6)
-                        data['{0}_{1}'.format(rds.identifier, 'total_memory')] = memory
-                        data['{0}_{1}'.format(rds.identifier, self.metrics[metric])] = stats / 10**6
+                        used_mem = memory - stats
+                        mem_name = self.metrics[metric]
+                        data['{0}_{1}'.format(inst, 'used_memory')] = used_mem
+                        data['{0}_{1}'.format(inst, 'total_memory')] = memory
+                        data['{0}_{1}'.format(inst, mem_name)] = stats
                     except IndexError as e:
-                        self.checks_logger.error('RDS: Unknown DB instance class "{}"'.format(info.instance_class))
+                        msg = 'RDS: Unknown DB instance class "{}"'
+                        self.checks_logger.error(
+                            msg.format(info.instance_class)
+                        )
                 elif metric == 'FreeStorageSpace':
                     info = rds.get_info()
                     storage = float(info.allocated_storage) * 1000
-                    data['{0}_{1}'.format(rds.identifier, self.metrics[metric])] = stats / 10**6
-                    data['{0}_{1}'.format(rds.identifier, 'used_diskusage')] = storage - (stats / 10**6)
-                    data['{0}_{1}'.format(rds.identifier, 'total_diskusage')] = storage
+                    used = storage - stats
+                    data['{0}_{1}'.format(inst, self.metrics[metric])] = stats
+                    data['{0}_{1}'.format(inst, 'used_diskusage')] = used
+                    data['{0}_{1}'.format(inst, 'total_diskusage')] = storage
                 elif metric in self.byte_related:
-                    data['{0}_{1}'.format(rds.identifier, self.metrics[metric])] = stats / 10**6
+                    data['{0}_{1}'.format(inst, self.metrics[metric])] = stats
                 else:
-                    data['{0}_{1}'.format(rds.identifier, self.metrics[metric])] = stats
+                    data['{0}_{1}'.format(inst, self.metrics[metric])] = stats
             except NoMetricError as e:
-                self.checks_logger.info('RDS: {} was not available'.format(metric))
+                msg = 'RDS: {} was not available'
+                self.checks_logger.info(msg.format(metric))
 
         return data
 

--- a/RDS/readme.md
+++ b/RDS/readme.md
@@ -1,0 +1,67 @@
+AWS RDS Server Density plugin
+=============================
+
+This plugin allows to monitor AWS RDS instances. It is based on the [Percona Monitoring Tools](https://github.com/percona/percona-monitoring-plugins/blob/master/cacti/scripts/ss_get_rds_stats.py) and uses [Python Boto](http://boto.cloudhackers.com/en/latest/) to query AWS CloudWatch.
+
+Setup
+-----
+
+1. Install python-boto `sudo apt-get install python-boto`
+2. Configure your [boto credentials](http://boto.cloudhackers.com/en/latest/boto_config_tut.html):
+   for this SD plugin need to create /etc/boto.cfg with the following contents:
+
+     ```
+     [Credentials]
+      aws_access_key_id = YOUR_KEY_ID
+      aws_secret_access_key = YOUR_ACCESS_KEY
+     ```
+    And give it secure permisions: `sudo chown sd-agent:sd-agent /etc/boto.cfg ; sudo chmod 0640 /etc/boto.cfg`
+3. Drop the RDS.py script in your plugin directory, most likely `/usr/local/share/sd-plugins/`
+4. Configure the plugin YAML file, for example in `/etc/sd-agent/conf.d/rds.yaml`:
+
+    ```
+    ---
+    default:
+      eu-west-1:
+        - my_monitored_rds_instance
+        - another_monitored_rds_instnace
+    ```
+5. Configure the plugin, in `/etc/sd-agent/plugins.cfg`:
+
+    ```
+    [RDS]
+    cfgfile = /etc/sd-agent/conf.d/rds.yaml
+    ```
+6. Restart the agent to apply changes `sudo service sd-agent restart`
+
+Troubleshooting
+---------------
+
+You can run the script directly from the command line to collect the metrics:
+
+```
+$ python RDS.py         
+{
+    "eu-west-1_sddb_BinLogDiskUsage": 817.8, 
+    "eu-west-1_sddb_CPUUtilization": 18.31, 
+    "eu-west-1_sddb_DatabaseConnections": 0.0, 
+    "eu-west-1_sddb_DiskQueueDepth": 0.0, 
+    "eu-west-1_sddb_ReadIOPS": 0.22, 
+    "eu-west-1_sddb_ReadLatency": 0.08, 
+    "eu-west-1_sddb_ReadThroughput": 136.54, 
+    "eu-west-1_sddb_ReplicaLag": 0.0, 
+    "eu-west-1_sddb_SwapUsage": 128614.4, 
+    "eu-west-1_sddb_TotalDiskUsage": 5368709120.0, 
+    "eu-west-1_sddb_TotalMemory": 660351221.76, 
+    "eu-west-1_sddb_UsedDiskUsage": 5368709101.69, 
+    "eu-west-1_sddb_UsedMemory": 660348572.86, 
+    "eu-west-1_sddb_WriteIOPS": 0.26, 
+    "eu-west-1_sddb_WriteLatency": 1.05, 
+    "eu-west-1_sddb_WriteThroughput": 2648.9
+}
+```
+
+Additional Notes
+----------------
+
+This plugin requires at least python-boto 2.35.2, Ubuntu 14.04 can use [Chris Lea's PPA](https://launchpad.net/~chris-lea/+archive/ubuntu/python-boto).

--- a/RDS/readme.md
+++ b/RDS/readme.md
@@ -3,6 +3,8 @@ AWS RDS Server Density plugin
 
 This plugin allows to monitor AWS RDS instances. It is based on the [Percona Monitoring Tools](https://github.com/percona/percona-monitoring-plugins/blob/master/cacti/scripts/ss_get_rds_stats.py) and uses [Python Boto](http://boto.cloudhackers.com/en/latest/) to query AWS CloudWatch.
 
+Every minute it pulls the 2 minute average from Cloudwatch and posts that to Server Density. The reason it pulls a 2 minute average rather than a 1 minute average is that when pulling a 1 minute average CPU utilization is not available. 
+
 Setup
 -----
 
@@ -12,7 +14,7 @@ Setup
      [RDS]
       aws_access_key_id = YOUR_KEY_ID
       aws_secret_access_key = YOUR_ACCESS_KEY
-      endpoint = YOUR_ENDPOINT
+      endpoints = YOUR_ENDPOINT
      ```
 
 3. Drop the RDS.py script in your plugin directory, most likely `/usr/local/share/sd-plugins/`. Check your `config.cfg` if you're unsure. 

--- a/RDS/readme.md
+++ b/RDS/readme.md
@@ -5,6 +5,8 @@ This plugin allows to monitor AWS RDS instances. It is based on the [Percona Mon
 
 Every minute it pulls the 2 minute average from Cloudwatch and posts that to Server Density. The reason it pulls a 2 minute average rather than a 1 minute average is that when pulling a 1 minute average CPU utilization is not available. 
 
+In the configuration you can get data from multiple endpoints by separating the endpoints through a comma. However, due to the nature of Boto making a request for each metric it's advisable to not have too many endpoints to allow the agent to make postbacks every minute. 
+
 Setup
 -----
 
@@ -14,7 +16,7 @@ Setup
      [RDS]
       aws_access_key_id = YOUR_KEY_ID
       aws_secret_access_key = YOUR_ACCESS_KEY
-      endpoints = YOUR_ENDPOINT
+      endpoints = RDS_ENDPOINT1,RDS_ENDPOINT2
      ```
 
 3. Drop the RDS.py script in your plugin directory, most likely `/usr/local/share/sd-plugins/`. Check your `config.cfg` if you're unsure. 

--- a/RDS/readme.md
+++ b/RDS/readme.md
@@ -7,32 +7,16 @@ Setup
 -----
 
 1. Install python-boto `sudo apt-get install python-boto`
-2. Configure your [boto credentials](http://boto.cloudhackers.com/en/latest/boto_config_tut.html):
-   for this SD plugin need to create /etc/boto.cfg with the following contents:
-
+2. Configure the plugin in `/etc/sd-agent/plugins.cfg` 
      ```
-     [Credentials]
+     [RDS]
       aws_access_key_id = YOUR_KEY_ID
       aws_secret_access_key = YOUR_ACCESS_KEY
+      endpoint = YOUR_ENDPOINT
      ```
-    And give it secure permisions: `sudo chown sd-agent:sd-agent /etc/boto.cfg ; sudo chmod 0640 /etc/boto.cfg`
-3. Drop the RDS.py script in your plugin directory, most likely `/usr/local/share/sd-plugins/`
-4. Configure the plugin YAML file, for example in `/etc/sd-agent/conf.d/rds.yaml`:
 
-    ```
-    ---
-    default:
-      eu-west-1:
-        - my_monitored_rds_instance
-        - another_monitored_rds_instnace
-    ```
-5. Configure the plugin, in `/etc/sd-agent/plugins.cfg`:
-
-    ```
-    [RDS]
-    cfgfile = /etc/sd-agent/conf.d/rds.yaml
-    ```
-6. Restart the agent to apply changes `sudo service sd-agent restart`
+3. Drop the RDS.py script in your plugin directory, most likely `/usr/local/share/sd-plugins/`. Check your `config.cfg` if you're unsure. 
+4. Restart the agent to apply changes `sudo service sd-agent restart`
 
 Troubleshooting
 ---------------
@@ -40,24 +24,30 @@ Troubleshooting
 You can run the script directly from the command line to collect the metrics:
 
 ```
-$ python RDS.py         
+$ python RDS.py -k YOUR_ACCESS_KEY -p YOUR_SECRET -e YOUR_ENDPOINT         
 {
-    "eu-west-1_sddb_BinLogDiskUsage": 817.8, 
-    "eu-west-1_sddb_CPUUtilization": 18.31, 
-    "eu-west-1_sddb_DatabaseConnections": 0.0, 
-    "eu-west-1_sddb_DiskQueueDepth": 0.0, 
-    "eu-west-1_sddb_ReadIOPS": 0.22, 
-    "eu-west-1_sddb_ReadLatency": 0.08, 
-    "eu-west-1_sddb_ReadThroughput": 136.54, 
-    "eu-west-1_sddb_ReplicaLag": 0.0, 
-    "eu-west-1_sddb_SwapUsage": 128614.4, 
-    "eu-west-1_sddb_TotalDiskUsage": 5368709120.0, 
-    "eu-west-1_sddb_TotalMemory": 660351221.76, 
-    "eu-west-1_sddb_UsedDiskUsage": 5368709101.69, 
-    "eu-west-1_sddb_UsedMemory": 660348572.86, 
-    "eu-west-1_sddb_WriteIOPS": 0.26, 
-    "eu-west-1_sddb_WriteLatency": 1.05, 
-    "eu-west-1_sddb_WriteThroughput": 2648.9
+  "somedbinstance_total_diskUsage": 5368709120.0,
+  "somedbinstance_database_connections": 0.0,
+  "somedbinstance_used_memory": 466810880.0,
+  "somedbinstance_free_storage_space": 4446867456.0,
+  "somedbinstance_network_transmit_throughput": 2634.76,
+  "somedbinstance_write_latency": 0.41,
+  "somedbinstance_read_latency": 0.2,
+  "somedbinstance_cpuutilization": 1.33,
+  "somedbinstance_maximum_used_transaction_ids": 616.0,
+  "somedbinstance_read_iops": 0.55,
+  "somedbinstance_write_throughput": 8328.87,
+  "somedbinstance_somedbinstance": 606930944.0,
+  "somedbinstance_oldest_replication_slot": -1.0,
+  "somedbinstance_network_received_throughput": 178.44,
+  "somedbinstance_write_iops": 0.78,
+  "somedbinstance_disk_queue_depth": 0.0,
+  "somedbinstance_transaction_logs_disk_usage": 570433832.0,
+  "somedbinstance_transaction_logs_generation": 0.0,
+  "somedbinstance_used_diskusage": 921841664.0,
+  "somedbinstance_total_memory": 1073741824,
+  "somedbinstance_read_throughput": 341.32,
+  "somedbinstance_swap_usage": 28672.0
 }
 ```
 


### PR DESCRIPTION
This adds RDS metrics that you can find [here](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/rds-metricscollected.html) 

A difference between this plugin and the plugin that it was adapted from is that it currently only accepts one database instance to check the RDS metrics from. This is a compromise. If we allowed to check from many it would likely slow down the agent because of the many requests sent to cloudwatch. 

You'll need to add the following into `plugins.cfg`
```[RDS]
aws_access_key_id: KEY
aws_secret_access_key: SECRET
endpoint: ENDPOINT
```

### Who should be notified:
- @bencer 

### Who should review
- @shurl  