### PR TITLE
Small fixes

### DIFF
--- a/OpenManage/readme.md
+++ b/OpenManage/readme.md
@@ -17,7 +17,9 @@ Installation - v2 Agent
 Configuration (Optional) v2 Agent
 ---
 Configuration is optional. If no config options are found then the defaults are used which are the values shown below
-* If you want to override the defaults add the following config options with your required values to `/etc/sd-agent/plugins.cfg` at the end of the file.  
+If you want to override the defaults add the following config options with your required values to `/etc/sd-agent/plugins.cfg` at the end of the file.  
+`disk_count` - the amount of disks to be exepcted by the plugin.
+`om_report` - the location of omreport, if it does not match the default.
 ```
 [OpenManage]
 disk_count: 2
@@ -38,19 +40,19 @@ Recommended alerts
 Disk States
 ---
 States taken from [http://www.dell.com/support/manuals/uk/en/ukbsdt1/dell-openmanage-server-administrator-v8.3/OMSS_UG/Physical-Disk-Or-Physical-Device-Properties?guid=GUID-D4CFE840-7128-46D2-B21C-39741581DABB&lang=en-us](OMSA 8.3 Documentation)
-`0` - Online 
-`1` - Degraded
-`2` - Failed 
-`3` - Offline 
-`4` - Rebuilding 
-`5` - Incompatible
-`6` - Removed 
-`7` - Clear 
-`8` - SMART Alert Detected 
-`9` - Foreign 
-`10` - Unsupported
-`11` - Replacing 
-`12` - Non-RAID
-`13` - Unknown 
-`14` - Ready
-`15` - Disk state could not be determined - The disk state could not be determined by the plugin as it does not match one of the above states. 
+*`0` - Online 
+*`1` - Degraded
+*`2` - Failed 
+*`3` - Offline 
+*`4` - Rebuilding 
+*`5` - Incompatible
+*`6` - Removed 
+*`7` - Clear 
+*`8` - SMART Alert Detected 
+*`9` - Foreign 
+*`10` - Unsupported
+*`11` - Replacing 
+*`12` - Non-RAID
+*`13` - Unknown 
+*`14` - Ready
+*`15` - Disk state could not be determined - The disk state could not be determined by the plugin as it does not match one of the above states. 

--- a/OpenManage/readme.md
+++ b/OpenManage/readme.md
@@ -1,7 +1,7 @@
 OpenManage RAID
 ===
 
-This plugin is for OpenManage RAID. 
+This plugin is for OpenManage RAID.
 
 Setup
 ---
@@ -17,8 +17,8 @@ Installation - v2 Agent
 Configuration (Optional) v2 Agent
 ---
 Configuration is optional. If no config options are found then the defaults are used which are the values shown below
-If you want to override the defaults add the following config options with your required values to `/etc/sd-agent/plugins.cfg` at the end of the file.  
-`disk_count` - the amount of disks to be exepcted by the plugin.
+If you want to override the defaults add the following config options with your required values to `/etc/sd-agent/plugins.cfg` at the end of the file.
+`disk_count` - the amount of disks to be expected by the plugin.
 `om_report` - the location of omreport, if it does not match the default.
 ```
 [OpenManage]
@@ -40,19 +40,19 @@ Recommended alerts
 Disk States
 ---
 States taken from [http://www.dell.com/support/manuals/uk/en/ukbsdt1/dell-openmanage-server-administrator-v8.3/OMSS_UG/Physical-Disk-Or-Physical-Device-Properties?guid=GUID-D4CFE840-7128-46D2-B21C-39741581DABB&lang=en-us](OMSA 8.3 Documentation)
-*`0` - Online 
+*`0` - Online
 *`1` - Degraded
-*`2` - Failed 
-*`3` - Offline 
-*`4` - Rebuilding 
+*`2` - Failed
+*`3` - Offline
+*`4` - Rebuilding
 *`5` - Incompatible
-*`6` - Removed 
-*`7` - Clear 
-*`8` - SMART Alert Detected 
-*`9` - Foreign 
+*`6` - Removed
+*`7` - Clear
+*`8` - SMART Alert Detected
+*`9` - Foreign
 *`10` - Unsupported
-*`11` - Replacing 
+*`11` - Replacing
 *`12` - Non-RAID
-*`13` - Unknown 
+*`13` - Unknown
 *`14` - Ready
-*`15` - Disk state could not be determined - The disk state could not be determined by the plugin as it does not match one of the above states. 
+*`15` - Disk state could not be determined - The disk state could not be determined by the plugin as it does not match one of the above states.

--- a/PortMon/PortMon.py
+++ b/PortMon/PortMon.py
@@ -55,9 +55,9 @@ if __name__ == "__main__":
     # Test ports: one that's not accessible and another that's open on my
     # MacBook.
     fake_rawConfig = {
-        'PortMon' : {
-            'portmon_targets':  "127.0.0.1:8542,192.168.6.6:1200",
-            'portmon_timeout':  "10"
+        'PortMon': {
+            'portmon_targets': "127.0.0.1:8542,192.168.6.6:1200",
+            'portmon_timeout': "10"
         }
     }
     pm = PortMon({}, {}, fake_rawConfig)

--- a/PortMon/PortMon.py
+++ b/PortMon/PortMon.py
@@ -7,8 +7,9 @@ import socket
 
 class PortMon(object):
     '''
-    Config should be in /etc/sd-agent/config.cfg like:
+    Config should be in /etc/sd-agent/plugins.cfg like:
 
+    [PortMon]
     portmon_timeout: 5
     portmon_targets: 127.0.0.1:22,192.168.3.4:5678
 
@@ -20,8 +21,8 @@ class PortMon(object):
         self.checksLogger = checksLogger
         self.rawConfig = rawConfig
 
-        self.timeout = int(rawConfig['Main'].get('portmon_timeout', 10))
-        targets_str = rawConfig['Main'].get('portmon_targets', '').strip()
+        self.timeout = int(rawConfig['PortMon'].get('portmon_timeout', 10))
+        targets_str = rawConfig['PortMon'].get('portmon_targets', '').strip()
         if len(targets_str):
             self.targets = targets_str.split(',')
         else:
@@ -54,8 +55,10 @@ if __name__ == "__main__":
     # Test ports: one that's not accessible and another that's open on my
     # MacBook.
     fake_rawConfig = {
-        'portmon_targets':  "127.0.0.1:8542,192.168.6.6:1200",
-        'portmon_timeout':  "10"
+        'PortMon' : {
+            'portmon_targets':  "127.0.0.1:8542,192.168.6.6:1200",
+            'portmon_timeout':  "10"
+        }
     }
     pm = PortMon({}, {}, fake_rawConfig)
     print pm.run()

--- a/PortMon/README.md
+++ b/PortMon/README.md
@@ -16,8 +16,32 @@ This means it's possible for SD to report your hosting platform as A-OK (which t
 
 Enter PortMon - a plugin to check your hosts can connect to TCP ports elsewhere and measure the time taken for connect() to complete.
 
+## Configuration (v2 Agent)
 
-## Configuration
+
+Ensure that your agent is setup for custom plugins - in your config.cfg you should have something like:
+
+```plugin_directory: /usr/local/sd-agent/plugins```
+
+See [information about custom plugins](https://support.serverdensity.com/hc/en-us/articles/213074438-Information-about-Custom-Plugins) for more information about custom plugins and configuring the agent for use with custom plugins.
+
+Then in `/etc/sd-agent/plugins.cfg` or `/etc/sd-agent/plugins.d/PortMon.cfg` add your config as required, an example is below:
+
+```
+[PortMon]
+portmon_timeout: 5
+portmon_targets: 127.0.0.1:22,my-rds-db.abcdef91p1.eu-west-1.rds.amazonaws.com:1433
+```
+
+Settings are simply:
+
+*  `portmon_timeout` - Integer timeout for connection attempts.  If this is reached the plugin records None for that target and goes on for the next.
+*  `portmon_targets` - A comma-separated list of TCP hosts/ports in the form `host:port`.
+
+Then restart the agent.
+
+
+## Configuration (Legacy v1 Agent)
 
 Config is intentionally simple.  Create the following section in your ServerDensity agent config, usually `/etc/sd-agent/config.cfg`.
 
@@ -28,6 +52,7 @@ Requires plugins to be enabled - in your config.cfg have something like:
 Config looks like:
 
 ```
+[PortMon]
 portmon_timeout: 5
 portmon_targets: 127.0.0.1:22,my-rds-db.abcdef91p1.eu-west-1.rds.amazonaws.com:1433
 ```


### PR DESCRIPTION
Small changes to PortMon to fix key errors on execution as a script and to use `[PortMon]` as the section identifier. 

Also docs update for PortMon and a small doc update for OpenManage (formatting mainly) 

@carlosperello can you review and merge if you're happy please? 