### PR TITLE
Update plugins repo link. Add v2 information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 Server Density v1 Agent Plugins
 ===
 
-These plugins are for the old Server Density agent v1. [Plugins for the v2 agent are in the agent repo](https://github.com/serverdensity/sd-agent/tree/master/checks.d).
+These plugins are for the old Server Density agent v1. [Plugins for the v2 agent are in the sd-agent-core-plugins repo](https://github.com/serverdensity/sd-agent-core-plugins/).
 
-See [information about custom plugins](https://support.serverdensity.com/hc/en-us/articles/213074438-Information-about-Custom-Plugins) to see how to install, configure & troubleshoot custom plugins. 
+See [information about v1 custom plugins](https://support.serverdensity.com/hc/en-us/articles/213074438-Information-about-Custom-Plugins) to see how to install, configure & troubleshoot custom plugins with the v1 agent.
+
+Whilst still supported, we encourage customers to use our v2 agent and to update or create any new custom plugins in the v2 custom plugin format.
+
+See [information about v2 custom plugins](https://support.serverdensity.com/hc/en-us/articles/115014887548) to see how to install, configure & troubleshoot custom plugins with the v2 agent.
 
 If you have problems, <a href="mailto:hello@serverdensity.com">email us</a>.


### PR DESCRIPTION
This PR updates the readme to fix the link to the v2 agent plugins and to add suggest users use v2, along with a link to info about v2 custom plugins.

@serverdensity/backend-engineering please can you review and merge? 